### PR TITLE
suggested shadow-cljs workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 /target/
+/public/js
 /.nrepl*
 /src/*.*
 /src/.*
@@ -7,3 +8,8 @@
 /node_modules
 
 .lumo_cache
+
+# just using cursive to edit the code
+project.clj
+.idea
+*.iml

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.3.2",
     "webpack-dev-server": "^2.4.5"
+  },
+  "dependencies": {
+    "shadow-cljs": "^0.3.0"
   }
 }

--- a/public/dev.html
+++ b/public/dev.html
@@ -1,0 +1,25 @@
+<html>
+<head><title>Stack Workflow</title>
+    <link href="http://logo.mvc-works.org/mvc.png" rel="icon" type="image/png"></link>
+    <link></link>
+    <meta charset="utf-8"></meta>
+    <meta content="width=device-width, initial-scale=1" name="viewport"></meta>
+    <meta content="{}" id="ssr-stages"></meta>
+    <style>body {margin: 0;}</style>
+    <style>body * {box-sizing: border-box;}</style>
+    <script id="config" type="text/edn">{:build? true}</script>
+</head>
+<body>
+<div id="app"></div>
+
+<!-- webpack css? there are no styles? -->
+<script src="/style.js"></script>
+<!-- --- -->
+
+<!-- cljs -->
+<script src="/js/main.js"></script>
+<script>client.main.init();</script>
+<!-- --- -->
+
+</body>
+</html>

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,13 @@
+[{:id :main
+  :target :browser
+
+  :public-dir "public/js"
+  :public-path "/js"
+
+  :modules
+  {:main
+   {:entries [client.main]}}
+
+  :devtools
+  {:before-load client.main/stop
+   :after-load client.main/start}}]

--- a/shadow-cljs.md
+++ b/shadow-cljs.md
@@ -1,0 +1,55 @@
+# shadow-cljs workflow
+
+```
+yarn
+
+# this process will become a CLJS-REPL
+shadow-cljs --build main --dev
+
+# second webpack process to webpacky things
+./node_modules/.bin/webpack-dev-server --config webpack.dev.coffee
+
+open http://localhost:8080/dev.html
+```
+
+I generated the `target/dev.html` once and then added the required changes manually. Moved everything to `public`, you don't need to do that. Just configure a different `:public-dir` in the `shadow-cjls.edn`.
+
+Once you have the `dev.html` open in a browser you can use the `shadow-cljs` process as REPL. Try `(js/alert "foo")`.
+
+`shadow-cljs.edn` configures the `main` build above.
+
+```
+[{:id :main
+  :target :browser
+
+  :public-dir "public/js"
+  :public-path "/js"
+
+  :modules
+  {:main
+   {:entries [client.main]}}
+
+  :devtools
+  {:before-load client.main/stop
+   :after-load client.main/start}}]
+```
+
+`:devtools` `:before-load` will be called before any code is reloaded, `:after-load` will be called once all code is loaded. To get things started the HTML will call `client.main/init` once and that will call `start`. You can use `init` to do things you only want done once. After that it is just `stop` -> `start`.
+
+The HMR and REPL code is injected automatically for `--dev`.
+
+
+```
+shadow-cljs --build main --once
+```
+
+`--once` will compile in `:dev` mode but without REPL or HMR
+
+
+```
+shadow-cljs --build main --release
+```
+
+`--release` will compile with `:advanced` compilation.
+
+The generated file is always `public/js/main.js` so no changes to the HTML are required to try a `--release` build.

--- a/src/client/main.cljs
+++ b/src/client/main.cljs
@@ -1,4 +1,3 @@
-
 (ns client.main
   (:require [respo.core :refer [render! clear-cache! falsify-stage! render-element]]
             [client.comp.container :refer [comp-container]]
@@ -14,27 +13,25 @@
   (let [target (.querySelector js/document "#app")]
     (render! (comp-container @ref-store) target dispatch!)))
 
-(defn on-jsload! [] (clear-cache!) (render-app!) (println "Code updated."))
-
 (def ssr-stages
   (let [ssr-element (.querySelector js/document "#ssr-stages")
         ssr-markup (.getAttribute ssr-element "content")]
     (read-string ssr-markup)))
 
-(defn -main! []
-  (enable-console-print!)
+(defn start []
   (if (not (empty? ssr-stages))
     (let [target (.querySelector js/document "#app")]
       (falsify-stage!
-       target
-       (render-element (comp-container @ref-store ssr-stages))
-       dispatch!)))
+        target
+        (render-element (comp-container @ref-store ssr-stages))
+        dispatch!)))
   (render-app!)
   (add-watch ref-store :changes render-app!)
-  (println "App started.")
-  (if (fn? js/module.hot.accept)
-    (do
-     (.log js/console "Accept changes!")
-     (js/module.hot.accept "./client.comp.container.js" on-jsload!))))
+  (js/console.log "app start"))
 
-(set! (.-onload js/window) -main!)
+(defn stop []
+  (clear-cache!)
+  (js/console.log "app stop"))
+
+(defn ^:export init []
+  (start))

--- a/webpack.dev.coffee
+++ b/webpack.dev.coffee
@@ -6,15 +6,12 @@ webpack = require 'webpack'
 module.exports =
   entry:
     style: 'respo-ui'
-    main: [
-      'shadow-cljs/client.main.js'
-    ]
   devServer:
     hot: true
-    contentBase: resolve(__dirname, 'target')
+    contentBase: resolve(__dirname, 'public')
     publicPath: '/'
   output:
-    path: path.join __dirname, '../target/'
+    path: path.join __dirname, '../public/webpack'
     filename: '[name].js'
   module:
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,6 +2434,10 @@ sha.js@^2.3.6:
   dependencies:
     inherits "^2.0.1"
 
+shadow-cljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-0.3.0.tgz#366c517633987afc1f7d50ea075819ea9f135797"
+
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"


### PR DESCRIPTION
# shadow-cljs workflow

```
yarn

# this process will become a CLJS-REPL
shadow-cljs --build main --dev

# second webpack process to webpacky things
./node_modules/.bin/webpack-dev-server --config webpack.dev.coffee

open http://localhost:8080/dev.html
```

I generated the `target/dev.html` once and then added the required changes manually. Moved everything to `public`, you don't need to do that. Just configure a different `:public-dir` in the `shadow-cjls.edn`.

Once you have the `dev.html` open in a browser you can use the `shadow-cljs` process as REPL. Try `(js/alert "foo")`.

`shadow-cljs.edn` configures the `main` build above.

```
[{:id :main
  :target :browser

  :public-dir "public/js"
  :public-path "/js"

  :modules
  {:main
   {:entries [client.main]}}

  :devtools
  {:before-load client.main/stop
   :after-load client.main/start}}]
```

`:devtools` `:before-load` will be called before any code is reloaded, `:after-load` will be called once all code is loaded. To get things started the HTML will call `client.main/init` once and that will call `start`. You can use `init` to do things you only want done once. After that it is just `stop` -> `start`.

The HMR and REPL code is injected automatically for `--dev`.


```
shadow-cljs --build main --once
```

`--once` will compile in `:dev` mode but without REPL or HMR


```
shadow-cljs --build main --release
```

`--release` will compile with `:advanced` compilation.

The generated file is always `public/js/main.js` so no changes to the HTML are required to try a `--release` build.